### PR TITLE
tidy the qkv

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3147,27 +3147,27 @@ class TestSDPACudaOnly(NNTestCase):
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
     def test_cudnn_attention_mask_broken_177842(self):
         # https://github.com/pytorch/pytorch/issues/177842
-        q = torch.randn(1, 10, 8, 8, dtype=torch.bfloat16, device='cuda')
-        k = torch.randn(1, 10, 1, 8, dtype=torch.bfloat16, device='cuda')
-        v = torch.randn(1, 10, 1, 8, dtype=torch.bfloat16, device='cuda')
+        q = torch.randn(1, 8, 10, 8, dtype=torch.bfloat16, device='cuda')
+        k = torch.randn(1, 1, 10, 8, dtype=torch.bfloat16, device='cuda')
+        v = torch.randn(1, 1, 10, 8, dtype=torch.bfloat16, device='cuda')
 
         attention_mask_custom = torch.zeros(10, 10, dtype=torch.bool).to("cuda")
         attention_mask_custom[:7, :7] = torch.tril(torch.ones(7, 7, dtype=torch.bool), diagonal=0)
 
         with sdpa_kernel(SDPBackend.MATH):
             attn_output_math = torch.nn.functional.scaled_dot_product_attention(
-                query=q.transpose(1, 2),
-                key=k.transpose(1, 2),
-                value=v.transpose(1, 2),
+                query=q,
+                key=k,
+                value=v,
                 attn_mask=attention_mask_custom,
                 is_causal=False,
                 enable_gqa=True,
             )
         with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
             attn_output_cudnn = torch.nn.functional.scaled_dot_product_attention(
-                query=q.transpose(1, 2),
-                key=k.transpose(1, 2),
-                value=v.transpose(1, 2),
+                query=q,
+                key=k,
+                value=v,
                 attn_mask=attention_mask_custom,
                 is_causal=False,
                 enable_gqa=True,
@@ -3179,18 +3179,18 @@ class TestSDPACudaOnly(NNTestCase):
         
         with sdpa_kernel(SDPBackend.MATH):
             attn_output_math = torch.nn.functional.scaled_dot_product_attention(
-                query=q.transpose(1, 2),
-                key=k.transpose(1, 2),
-                value=v.transpose(1, 2),
+                query=q,
+                key=k,
+                value=v,
                 attn_mask=attention_mask_custom,
                 is_causal=False,
                 enable_gqa=True,
             )
         with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
             attn_output_cudnn = torch.nn.functional.scaled_dot_product_attention(
-                query=q.transpose(1, 2),
-                key=k.transpose(1, 2),
-                value=v.transpose(1, 2),
+                query=q,
+                key=k,
+                value=v,
                 attn_mask=attention_mask_custom,
                 is_causal=False,
                 enable_gqa=True,
@@ -3202,18 +3202,18 @@ class TestSDPACudaOnly(NNTestCase):
         
         with sdpa_kernel(SDPBackend.MATH):
             attn_output_math = torch.nn.functional.scaled_dot_product_attention(
-                query=q.transpose(1, 2),
-                key=k.transpose(1, 2),
-                value=v.transpose(1, 2),
+                query=q,
+                key=k,
+                value=v,
                 attn_mask=attention_mask_custom,
                 is_causal=False,
                 enable_gqa=True,
             )
         with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
             attn_output_cudnn = torch.nn.functional.scaled_dot_product_attention(
-                query=q.transpose(1, 2),
-                key=k.transpose(1, 2),
-                value=v.transpose(1, 2),
+                query=q,
+                key=k,
+                value=v,
                 attn_mask=attention_mask_custom,
                 is_causal=False,
                 enable_gqa=True,


### PR DESCRIPTION
It is not a necessary commit, but if you think it can make the code style tidier, you can choose to merge it.

I don't know if scaled_dot_product_attention encourages users to explicitly call transpose(1, 2). If removing it could easily lead to misunderstandings or goes against common writing practices, please ignore and close this PR

sorry for my pool English so i choose to use LLM for translate